### PR TITLE
Various minor bugfixes

### DIFF
--- a/elina_linearize/elina_generic.c
+++ b/elina_linearize/elina_generic.c
@@ -177,7 +177,7 @@ elina_generic_meet_quasilinearize_lincons_array(elina_manager_t* man,
   man->result.flag_exact = man->result.flag_best = true;
 
   if (is_bottom(man,abs) || array->size==0){
-    res = destructive ? abs : copy(abs);
+    res = destructive ? abs : copy(man, abs);
   }
   else {
     array2 = elina_quasilinearize_lincons0_array(man,abs,array,&exact,

--- a/elina_linearize/elina_interval_arith.c
+++ b/elina_linearize/elina_interval_arith.c
@@ -112,7 +112,8 @@ void elina_interval_abs(elina_interval_t *a, elina_interval_t *b, elina_scalar_d
     elina_interval_neg(a,b);
   }
   else {
-    elina_scalar_max(a->sup,b->inf,b->sup);
+    elina_scalar_neg(a->inf, b->inf);
+    elina_scalar_max(a->sup,a->inf,b->sup);
     elina_scalar_set_to_int(a->inf,0,discr);
   }
 }

--- a/elina_linearize/elina_interval_arith.c
+++ b/elina_linearize/elina_interval_arith.c
@@ -366,7 +366,10 @@ void elina_interval_magnitude(elina_scalar_t *a, elina_interval_t *b)
 {
   if (elina_scalar_sgn(b->inf)>=0) elina_scalar_set(a,b->sup);
   else if (elina_scalar_sgn(b->sup)<=0) elina_scalar_neg(a,b->inf);
-  else elina_scalar_max(a,b->inf,b->sup);
+  else {
+    elina_scalar_neg(a,b->inf);
+    elina_scalar_max(a,a,b->sup);
+  }
 }
 
 void elina_interval_range_rel(elina_scalar_t *a, elina_interval_t *b, elina_scalar_discr_t discr)

--- a/elina_linearize/elina_linearize.c
+++ b/elina_linearize/elina_linearize.c
@@ -131,7 +131,7 @@ char eval_elina_cstlincons0(elina_lincons0_t* cons)
   case ELINA_CONS_DISEQ:
     if(equality){
 	int sgn = elina_scalar_sgn(cst->val.scalar);
-	res = (sgn==0 ? 2 : 1);
+	res = (sgn==0 ? 0 : 1);
     }
     else{
       sup = cst->val.interval->sup;

--- a/elina_linearize/elina_rat.h
+++ b/elina_linearize/elina_rat.h
@@ -64,8 +64,8 @@ static inline bool elina_rat_infty(elina_rat_t *r){
 
 /*  int -> elina_rat */
 static inline bool elina_rat_set_int(elina_rat_t *a, long long int num){
-	a->n = 1;
-	a->d = 0;
+	a->n = num;
+	a->d = 1;
 	return true;
 }
 


### PR DESCRIPTION
While trying to understand and document the API, I have found a few minor bugs in the library. Except for a small remark on `elina_interval_abs`, I believe I have fixed them.

## `elina_interval_abs`

When the source interval contains 0 in its interior, i.e., `inf < 0 < sup`, the result is [0, sup] rather than [0, max(-inf, sup)]. The operation `elina_scalar_max(a->sup, b->inf, b->sup)` in line 115 should negate the infimum.

Empty intervals are also not handled correctly. For example the interval [1, -1] would be mapped to [0, 1]. Is this intended? Is the precondition that the interval is not empty assumed?

## `elina_interval_magnitude`

When the source interval contains 0 in its interior, i.e., `inf < 0 < sup`, the result of this operation is always `sup`. The operation `elina_scalar_max(a, b->inf, b->sup)` in line 368 should negate the infimum.

## `elina_rat_set_int`

This method does not set the passed value at all. It simply stores ∞.

## `eval_elina_cstlincons0`

Constraint 0 != 0 is classified incorrectly. It is never satisfiable, but "may be satisfied" is returned. I changed `sgn == 0 ? 2 : 1` to `sgn == 0 ? 0 : 1` to fix this.

## `elina_generic_meet_quasilinearize_lincons_array`

In line 180, the function pointer to `copy` is called incorrectly. It is missing `manager` as a first argument.