### PR TITLE
Revise build script using opam

### DIFF
--- a/configure
+++ b/configure
@@ -587,6 +587,11 @@ ABSOLUTE_DYLIB_INSTALL_NAMES = $absolute_dylib_install_names
 ifneq (\$(ABSOLUTE_DYLIB_INSTALL_NAMES),)
   CC_ELINA_DYLIB += -install_name \$(ELINA_PREFIX)/lib/\$@
   CXX_ELINA_DYLIB += -install_name \$(ELINA_PREFIX)/lib/\$@
+else
+ifneq (\$(USE_OPAM),)
+  CC_ELINA_DYLIB += -Wl,-rpath=\$(ELINA_PREFIX)/lib
+  CXX_ELINA_DYLIB += -Wl,-rpath=\$(ELINA_PREFIX)/lib
+endif
 endif
 
 EOF

--- a/ocaml_interface/Makefile
+++ b/ocaml_interface/Makefile
@@ -54,7 +54,7 @@ APRON_CAML_INCLUDE = $(shell $(OCAMLFIND) query apron)
 
 CAML_TO_INSTALL = \
 elina_poly.idl elina_poly.mli elina_poly.ml elina_poly.cmi \
-elina_poly.cma \
+elina_poly.a elina_poly.cma elina_poly.cmx elina_poly.cmxa \
 libelina_poly_caml.a \
 
 ifneq ($(HAS_OCAMLOPT),)

--- a/opam
+++ b/opam
@@ -9,8 +9,8 @@ license: "LGPL-3"
 build: [
   ["sh" "./configure" "--prefix" "%{share}%/elina"
                       "--apron-prefix" "%{share}%/apron"
-                      "--no-java"
                       "--use-opam"
+                      "--use-apron"
                       "--absolute-dylibs" { os = "darwin" } ]
   [make "-j%{jobs}%"]
 ]
@@ -23,7 +23,7 @@ remove: [
 ]
 tags: [ "flags:light-uninstall" ]
 depends: [
-  "ocamlfind"
+  "ocamlfind" {build}
   "camlidl"
   "mlgmpidl"
   "conf-perl"


### PR DESCRIPTION
It sets `rpath`s of `.so` files, so they can find the other shared objects at runtime.