### PR TITLE
elina_zonotope bugfix

### DIFF
--- a/elina_zonotope/elina_box_meetjoin.c
+++ b/elina_zonotope/elina_box_meetjoin.c
@@ -488,14 +488,31 @@ static bool elina_double_boxize_lincons0(double* res_inf, double * res_sup,
     elina_coeff_swap(tmp,coeff);
     double inf = 0.0;
     double sup = 0.0;
-    
-    if(tmp->discr==ELINA_COEFF_SCALAR){
-	inf = -tmp->val.scalar->val.dbl;
-	sup = tmp->val.scalar->val.dbl;
-    }
-    else{
-	inf = -tmp->val.interval->inf->val.dbl;
-	sup = tmp->val.interval->sup->val.dbl;
+    double d;
+
+    if (tmp->discr==ELINA_COEFF_SCALAR) {
+        if (tmp->discr == ELINA_SCALAR_DOUBLE) {
+            inf = -tmp->val.scalar->val.dbl;
+            sup = tmp->val.scalar->val.dbl;
+        } else {
+            elina_double_set_scalar(&d,tmp->val.scalar,GMP_RNDD);
+            inf = -d;
+            elina_double_set_scalar(&d,tmp->val.scalar,GMP_RNDU);
+            sup = d;
+        }
+    } else {
+        if (tmp->val.interval->inf->discr == ELINA_SCALAR_DOUBLE) {
+            inf = -tmp->val.interval->inf->val.dbl;
+        } else {
+            elina_double_set_scalar(&d,tmp->val.interval->inf,GMP_RNDD);
+            inf = -d;
+        }
+        if (tmp->val.interval->sup->discr == ELINA_SCALAR_DOUBLE) {
+            sup = tmp->val.interval->sup->val.dbl;
+        } else {
+            elina_double_set_scalar(&d,tmp->val.interval->inf,GMP_RNDU);
+            sup = d;
+        }
     }
     /* 2. evaluate e' */
     elina_double_interval_eval_elina_linexpr0(&itv_inf, & itv_sup, expr,env_inf, env_sup, discr);

--- a/elina_zonotope/zonotope_internal.c
+++ b/elina_zonotope/zonotope_internal.c
@@ -292,18 +292,43 @@ zonotope_aff_t * zonotope_aff_from_linexpr0(zonotope_internal_t* pr, elina_linex
     elina_coeff_t *coeff;
     zonotope_aff_t *res = zonotope_aff_alloc_init(pr);
     elina_coeff_t * cst = &(expr->cst);
-    if(cst->discr==ELINA_COEFF_SCALAR){
-	res->c_inf = -cst->val.scalar->val.dbl;
-	res->c_sup = cst->val.scalar->val.dbl;
-	res->itv_inf = -cst->val.scalar->val.dbl;
-	res->itv_sup = cst->val.scalar->val.dbl;
+
+    if(cst->discr==ELINA_COEFF_SCALAR) {
+        if (cst->val.scalar->discr == ELINA_SCALAR_DOUBLE) {
+            res->c_inf = -cst->val.scalar->val.dbl;
+            res->c_sup = cst->val.scalar->val.dbl;
+            res->itv_inf = -cst->val.scalar->val.dbl;
+            res->itv_sup = cst->val.scalar->val.dbl;
+        } else {
+            double inf,sup;
+            elina_double_set_scalar(&inf,cst->val.scalar,GMP_RNDD);
+            elina_double_set_scalar(&sup,cst->val.scalar,GMP_RNDU);
+            res->c_inf = -inf;
+            res->c_sup = sup;
+            res->itv_inf = -inf;
+            res->itv_sup = sup;
+        }
+    } else {
+        if (cst->val.interval->inf->discr == ELINA_SCALAR_DOUBLE) {
+            res->c_inf = -cst->val.interval->inf->val.dbl;
+            res->itv_inf = -cst->val.interval->inf->val.dbl;
+        } else {
+            double inf;
+            elina_double_set_scalar(&inf,cst->val.scalar,GMP_RNDD);
+            res->c_inf = -inf;
+            res->itv_inf = -inf;
+        }
+        if (cst->val.interval->sup->discr == ELINA_SCALAR_DOUBLE) {
+            res->c_sup = cst->val.interval->sup->val.dbl;
+            res->itv_sup = cst->val.interval->sup->val.dbl;
+        } else {
+            double sup;
+            elina_double_set_scalar(&sup,cst->val.scalar,GMP_RNDU);
+            res->c_sup = sup;
+            res->itv_sup = sup;
+        }
     }
-    else{
-	res->c_inf = -cst->val.interval->inf->val.dbl;
-	res->c_sup = cst->val.interval->sup->val.dbl;
-	res->itv_inf = -cst->val.interval->inf->val.dbl;
-	res->itv_sup = cst->val.interval->sup->val.dbl;
-    }
+
 	//printf("size: %zu\n",expr->size);
 	//fflush(stdout);
     elina_linexpr0_ForeachLinterm(expr,i,dim,coeff) {

--- a/elina_zonotope/zonotope_internal.h
+++ b/elina_zonotope/zonotope_internal.h
@@ -1398,7 +1398,7 @@ static inline zonotope_aff_t * zonotope_aff_join_constrained6(zonotope_internal_
 
 	elina_scalar_sub(c0,dmax,dmin, ELINA_SCALAR_DOUBLE);
 	elina_scalar_div_2(c0, c0);
-	res->c_inf = c0->val.dbl;
+	res->c_inf = -c0->val.dbl;
 	res->c_sup = c0->val.dbl; 
 
 	if (elina_scalar_cmp(c1->inf,c2->inf) < 0) {


### PR DESCRIPTION
Hi Gagan.

When we used elina_zonotope, we found that the output is abnormal. Through debugging, we think there is a bug in the following code snippet.

https://github.com/eth-sri/ELINA/blob/e824898a9f1c50dc76efb3fd52b59d8f1db6c080/elina_zonotope/zonotope_internal.h#L1399-L1402

When we changed the 1401st line as follows, the precision is improved a lot.

```
res->c_inf = -c0->val.dbl;
```

And when we convert an abstract element into a lincons array, the elina abstract0 API generates MPQ scalars, which is then read as a double  when we use this lincons array to intersect with a zonotope in the following code snippet.

https://github.com/eth-sri/ELINA/blob/3be0c7e81cfb06dc2fdc7f135d9884504ae94e0e/elina_zonotope/elina_box_meetjoin.c#L385-L392

Thanks,
Jianlin