### PR TITLE
Add ./configure option to suppress overflow warnings

### DIFF
--- a/configure
+++ b/configure
@@ -27,6 +27,7 @@ where options include:
   -use-ocamlfind       enable OCamlfind support
   -use-java            enable Java support (only available with APRON)
   -use-opam            use opam to install ELINA
+  -no-warn-overflow    Silence all output relating to sound overflow
 
 Environment variables that affect configuration:
   CC                   C compiler to use (default: gcc)
@@ -55,6 +56,7 @@ has_java=0
 use_opam=0
 has_apron=0
 has_vector=0
+extra_elina_options=""
 force_absolute_dylib_install_names=0;
 while : ; do
     case "$1" in
@@ -78,6 +80,8 @@ while : ; do
         -java-prefix|--java-prefix)
             java_prefix="$2"
             shift;;
+        -no-warn-overflow|--no-warn-overflow)
+            extra_elina_options+="-DNO_WARN_OVERFLOW";;
         -use-ocaml|--use-ocaml)
             has_ocaml=1;;
         -use-ocamlfind|--use-ocamlfind)
@@ -287,7 +291,7 @@ done
 if test "$cc" = "none"; then echo "no C compiler found"; exit 1; fi
 
 acc=""
-for i in $c_cxx_flags -Werror-implicit-function-declaration -Wbad-function-cast -Wstrict-prototypes -Wno-strict-overflow -std=c99 $CFLAGS $LDFLAGS
+for i in $c_cxx_flags -Werror-implicit-function-declaration -Wbad-function-cast -Wstrict-prototypes -Wno-strict-overflow -std=c99 $CFLAGS $LDFLAGS $extra_elina_options
 do
     checkcomp "$cc" "$i"
 done

--- a/elina_poly/opt_pk_vector.c
+++ b/elina_poly/opt_pk_vector.c
@@ -566,8 +566,10 @@ void opt_vector_combine(opt_pk_internal_t* opk,
 
     ov3[k] = 0;
     if(flag){
-             fprintf(stderr,"exception \n");
+#ifndef NO_WARN_OVERFLOW
+             fprintf(stderr,"overflow exception \n");
              fflush(stderr);
+#endif /* NO_WARN_OVERFLOW */
              opk->exn = ELINA_EXC_OVERFLOW;
              return ;
     }


### PR DESCRIPTION
This addresses part of the concerns in issue #39. Namely, if we know the
overflow is sound, then we can choose to skip printing to `stderr` when the
sound overflow occurs.

The implementation is straightforward:

* We added an option to `./configure`: `-no-warn-overflow`

* When enabled, this adds `-DNO_WARN_OVERFLOW` to `extra_elina_options`

* The printing to `stderr` in `elina_poly/opt_pk/vector.c:570` is now under
  a CPP macro that checks whether `-DNO_WARN_OVERFLOW` is defined.