### PR TITLE
Fix double free.

### DIFF
--- a/elina_zones/opt_mat.c
+++ b/elina_zones/opt_mat.c
@@ -788,13 +788,13 @@ bool is_equal_zones_mat(opt_zones_mat_t *oz1, opt_zones_mat_t *oz2, unsigned sho
 					if(!ci){
 						if(m2[i1]!=INFINITY){
 							free(ca);
-							free(arr_map2);
+							free(arr_map1);
 							free_array_comp_list(acl);
 							return false;
 						}
 						if(m2[n*i1]!=INFINITY){
 							free(ca);
-							free(arr_map2);
+							free(arr_map1);
 							free_array_comp_list(acl);
 							return false;
 						}


### PR DESCRIPTION
There is potential double free on memory pointed to by `arr_map2` (allocated on line 727) and a potential memory leak of memory pointed to by `arr_map1` (allocated on line 765). This pull request should fix these issues.

N.B.: I found this issue using [deepcode](https://www.deepcode.ai/app/gh/eth-sri/ELINA/3fc0d03687ca166f94812489adecca0a8ca361ca/_/%2Felina_zones%2Fopt_mat.c/cpp%2Fdc%2FCDoubleFree/791/code/). You can see all the issues that DeepCode finds for your repository [here](https://www.deepcode.ai/app/gh/eth-sri/ELINA/master/_/dashboard/url). If you want you can enable DeepCodes AI code review for your repository to be notified of this and other issues automatically in the future. It is **free, no strings attached**. To do this just head over to our [website](deepcode.ai). Detailed instructions are also available as [video](https://www.youtube.com/watch?v=SwUZ-IAccyU).

