### PR TITLE
fix memory leaks (found by Valgrind)

### DIFF
--- a/elina_oct/opt_oct_predicate.c
+++ b/elina_oct/opt_oct_predicate.c
@@ -419,7 +419,8 @@ bool opt_oct_is_dimension_unconstrained(elina_manager_t* man, opt_oct_t* o,
 			if(m[opt_matpos2(d2,d2+1)]!=INFINITY || m[opt_matpos2(d2+1,d2)]!=INFINITY){
 				#if defined(TIMING)
 					record_timing(oct_is_unconstrained_time);
-   				 #endif
+   				#endif
+				free(ca);
 				return false;
 			}
 		}
@@ -427,25 +428,29 @@ bool opt_oct_is_dimension_unconstrained(elina_manager_t* man, opt_oct_t* o,
 			if(m[opt_matpos2(2*j1,d2)]!=INFINITY){
 				#if defined(TIMING)
 					record_timing(oct_is_unconstrained_time);
-   				 #endif
+   				#endif
+				free(ca);	
 				return false;
 			}
 			if(m[opt_matpos2(2*j1+1,d2)]!=INFINITY){
 				#if defined(TIMING)
 					record_timing(oct_is_unconstrained_time);
-   				 #endif
+   				#endif
+				free(ca);
 				return false;
 			}
 			if(m[opt_matpos2(2*j1,d2+1)]!=INFINITY){
 				#if defined(TIMING)
 					record_timing(oct_is_unconstrained_time);
-   				 #endif
+   				#endif
+				free(ca);
 				return false;
 			}
 			if(m[opt_matpos2(2*j1+1,d2+1)]!=INFINITY){
 				#if defined(TIMING)
 					record_timing(oct_is_unconstrained_time);
-   				 #endif
+   				#endif
+				free(ca);
 				return false;
 			}
 		}

--- a/elina_zones/opt_mat.c
+++ b/elina_zones/opt_mat.c
@@ -601,12 +601,14 @@ bool is_lequal_zones_mat(opt_zones_mat_t *oz1, opt_zones_mat_t *oz2, unsigned sh
 				int ind = n*i1;
 				if(!ci){
 					if((m2[i1]!=INFINITY) || (m2[ind]!=INFINITY) ){
+					        free(ca);
 						free(arr_map1);
 						return false;
 					}
 				}
 				else{
 					if((m1[i1] > m2[i1]) || (m1[ind] > m2[ind]) ){
+					        free(ca);
 						free(arr_map1);
 						return false;
 					}
@@ -2310,7 +2312,7 @@ bool opt_zones_mat_add_lincons(opt_zones_internal_t * pr,opt_zones_mat_t *oz, un
 		insert_comp_list_with_union(oz->acl,clb,dim);
 		
 	}
-    }
+     }
 	
     z = zone_expr_of_linexpr(pr,pr->tmp,array->p[i].linexpr0,intdim,dim);
      	

--- a/elina_zones/opt_zones_closure.c
+++ b/elina_zones/opt_zones_closure.c
@@ -267,6 +267,7 @@ bool strengthening_single_comp_zones(opt_zones_mat_t * oz, comp_list_t * cl, uns
 		int i1 = ca[i]+1;
 		int ind = i1*n + i1;
 		if(m[ind] < 0){
+		        free(ca);
 			return true;
 		}
 		else{

--- a/elina_zones/opt_zones_predicate.c
+++ b/elina_zones/opt_zones_predicate.c
@@ -424,14 +424,17 @@ bool opt_zones_is_dimension_unconstrained(elina_manager_t* man, opt_zones_t* o,
 		unsigned short int j1 = ca[j];
 		if(j1==dim){
 			if(m[j1+1]!=INFINITY || m[n*(j1+1)]!=INFINITY){
+			        free(ca);
 				return false;
 			}
 		}
 		else{
 			if(m[n*(j1+1) + dim+1]!=INFINITY){
+			        free(ca);
 				return false;
 			}
 			if(m[n*(dim+1) + j1+1]!=INFINITY){
+			        free(ca);
 				return false;
 			}
 		}


### PR DESCRIPTION
There are other memory leaks that I didn't have time to look at. All of them are in the zones domain. 
Sorry that I don't provide a test case but this is what Valgrind says. Hopefully this is enough to give you an idea:

```
==94482== 11,880 bytes in 297 blocks are definitely lost in loss record 33 of 35
==94482==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==94482==    by 0x506E158: elina_linexpr0_alloc (elina_linexpr0.c:139)
==94482==    by 0x6A388D8: elina_linexpr0_add (elina_linexpr0_arith.c:144)
==94482==    by 0x6A3CCD7: elina_texpr0_node_intlinearize (elina_linearize_texpr.c:726)
==94482==    by 0x6A3CCD7: elina_interval_intlinearize_texpr0_rec (elina_linearize_texpr.c:923)
==94482==    by 0x6A3CC73: elina_texpr0_node_intlinearize (elina_linearize_texpr.c:714)
==94482==    by 0x6A3CC73: elina_interval_intlinearize_texpr0_rec (elina_linearize_texpr.c:923)
==94482==    by 0x6A3E67B: elina_intlinearize_elina_tcons0_array (elina_linearize_texpr.c:1597)
==94482==    by 0x6A3E8E5: elina_intlinearize_tcons0_array (elina_linearize_texpr.c:1680)
==94482==    by 0x6A34DB6: elina_generic_meet_intlinearize_tcons_array (elina_generic.c:222)
==94482==    by 0x528FDA8: opt_zones_meet_tcons_array (opt_zones_transfer.c:151)
==94482==    by 0x6A359E4: elina_generic_asssub_texpr_array (elina_generic.c:506)
==94482==    by 0x528FC41: elina_generic_assign_texpr_array (elina_generic.h:217)
==94482==    by 0x528FC41: opt_zones_assign_texpr_array (opt_zones_transfer.c:61)
==94482==    by 0x5073B12: elina_abstract0_asssub_texpr_array (elina_abstract0.c:1106)
```

```
==94482== 12,520 bytes in 313 blocks are definitely lost in loss record 34 of 35
==94482==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==94482==    by 0x506E158: elina_linexpr0_alloc (elina_linexpr0.c:139)
==94482==    by 0x6A388D8: elina_linexpr0_add (elina_linexpr0_arith.c:144)
==94482==    by 0x6A38BDD: elina_linexpr0_sub (elina_linexpr0_arith.c:211)
==94482==    by 0x6A3D080: elina_texpr0_node_intlinearize (elina_linearize_texpr.c:731)
==94482==    by 0x6A3D080: elina_interval_intlinearize_texpr0_rec (elina_linearize_texpr.c:923)
==94482==    by 0x6A3E67B: elina_intlinearize_elina_tcons0_array (elina_linearize_texpr.c:1597)
==94482==    by 0x6A3E8E5: elina_intlinearize_tcons0_array (elina_linearize_texpr.c:1680)
==94482==    by 0x6A34DB6: elina_generic_meet_intlinearize_tcons_array (elina_generic.c:222)
==94482==    by 0x528FDA8: opt_zones_meet_tcons_array (opt_zones_transfer.c:151)
==94482==    by 0x6A359E4: elina_generic_asssub_texpr_array (elina_generic.c:506)
==94482==    by 0x528FC41: elina_generic_assign_texpr_array (elina_generic.h:217)
==94482==    by 0x528FC41: opt_zones_assign_texpr_array (opt_zones_transfer.c:61)
==94482==    by 0x5073B12: elina_abstract0_asssub_texpr_array (elina_abstract0.c:1106)
```

```
==94482== 960 bytes in 40 blocks are definitely lost in loss record 29 of 35
==94482==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==94482==    by 0x682A7BD: create_comp_list (comp_list.c:44)
==94482==    by 0x528A9B1: linexpr0_to_comp_list_zones (opt_mat.c:2146)
==94482==    by 0x528B097: opt_zones_mat_add_lincons (opt_mat.c:2247)
==94482==    by 0x528F9CD: opt_zones_meet_lincons_array (opt_zones_transfer.c:116)
==94482==    by 0x507350E: elina_abstract0_meet_lincons_array (elina_abstract0.c:984)
```

```
==94482== 288 bytes in 18 blocks are definitely lost in loss record 26 of 35
==94482==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==94482==    by 0x682B03D: create_array_comp_list (array_comp_list.c:57)
==94482==    by 0x5285695: opt_zones_mat_alloc (opt_mat.c:202)
==94482==    by 0x528E263: opt_zones_join (opt_zones_nary.c:149)
```

```
==94482== 64 bytes in 4 blocks are definitely lost in loss record 18 of 35
==94482==    at 0x4C31B0F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==94482==    by 0x682B03D: create_array_comp_list (array_comp_list.c:57)
==94482==    by 0x5285695: opt_zones_mat_alloc (opt_mat.c:202)
==94482==    by 0x528E4F5: opt_zones_widening (opt_zones_nary.c:218)
==94482==    by 0x50746C8: elina_abstract0_widening (elina_abstract0.c:1360)
```

```
==94482== 6 bytes in 1 blocks are definitely lost in loss record 2 of 35
==94482==    at 0x4C33B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==94482==    by 0x682C37C: union_array_comp_list (union.c:232)
==94482==    by 0x5288221: sparse_join_zones_mat (opt_mat.c:1216)
==94482==    by 0x528E319: opt_zones_join (opt_zones_nary.c:156)
```

