### PR TITLE
Porting to non-x86 (esp. aarch64)

### DIFF
--- a/elina_auxiliary/elina_abstract0.c
+++ b/elina_auxiliary/elina_abstract0.c
@@ -631,7 +631,7 @@ void elina_abstract0_fprint(FILE* stream, elina_manager_t* man,
 			 char** name_of_dim)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_FPRINT,man,a)){
-    void (*ptr)(FILE*,elina_manager_t*,...) = man->funptr[ELINA_FUNID_FPRINT];
+    void (*ptr)(FILE*,elina_manager_t*,void*,char**) = man->funptr[ELINA_FUNID_FPRINT];
     ptr(stream,man,a->value,name_of_dim);
   }
   else {
@@ -645,7 +645,7 @@ void elina_abstract0_fprintdiff(FILE* stream, elina_manager_t* man,
 {
   if (elina_abstract0_checkman2(ELINA_FUNID_FPRINTDIFF,man,a,b) &&
       elina_abstract0_check_abstract2(ELINA_FUNID_FPRINTDIFF,man,a,b) ){
-    void (*ptr)(FILE*,elina_manager_t*,...) = man->funptr[ELINA_FUNID_FPRINTDIFF];
+    void (*ptr)(FILE*,elina_manager_t*,void*,void*,char**) = man->funptr[ELINA_FUNID_FPRINTDIFF];
     ptr(stream,man,a->value,b->value,name_of_dim);
   }
   else {
@@ -691,17 +691,17 @@ elina_abstract0_t* elina_abstract0_deserialize_raw(elina_manager_t* man, void* p
 /* ============================================================ */
 elina_abstract0_t* elina_abstract0_bottom(elina_manager_t* man, size_t intdim, size_t realdim)
 {
-  void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_BOTTOM];
+  void* (*ptr)(elina_manager_t*,size_t,size_t) = man->funptr[ELINA_FUNID_BOTTOM];
   return elina_abstract0_cons(man,ptr(man,intdim,realdim));
 }
 elina_abstract0_t* elina_abstract0_top(elina_manager_t* man, size_t intdim, size_t realdim){
-  void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_TOP];
+  void* (*ptr)(elina_manager_t*,size_t,size_t) = man->funptr[ELINA_FUNID_TOP];
   return elina_abstract0_cons(man,ptr(man,intdim,realdim));
 }
 elina_abstract0_t* elina_abstract0_of_box(elina_manager_t* man,
 				    size_t intdim, size_t realdim,
 				    elina_interval_t** tinterval){
-  void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_OF_BOX];
+  void* (*ptr)(elina_manager_t*,size_t,size_t,elina_interval_t**) = man->funptr[ELINA_FUNID_OF_BOX];
   return elina_abstract0_cons(man,ptr(man,intdim,realdim,tinterval));
 }
 
@@ -776,7 +776,7 @@ bool elina_abstract0_sat_lincons(elina_manager_t* man, elina_abstract0_t* a, eli
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_SAT_LINCONS,man,a) &&
       elina_abstract0_check_linexpr(ELINA_FUNID_SAT_LINCONS,man,_elina_abstract0_dimension(a),lincons->linexpr0) ){
-    bool (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_SAT_LINCONS];
+    bool (*ptr)(elina_manager_t*,void*,elina_lincons0_t*) = man->funptr[ELINA_FUNID_SAT_LINCONS];
     return ptr(man,a->value,lincons);
   }
   else {
@@ -788,7 +788,7 @@ bool elina_abstract0_sat_tcons(elina_manager_t* man, elina_abstract0_t* a, elina
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_SAT_TCONS,man,a) &&
       elina_abstract0_check_texpr(ELINA_FUNID_SAT_TCONS,man,_elina_abstract0_dimension(a),tcons->texpr0) ){
-    bool (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_SAT_TCONS];
+    bool (*ptr)(elina_manager_t*,void*,elina_tcons0_t*) = man->funptr[ELINA_FUNID_SAT_TCONS];
     return ptr(man,a->value,tcons);
   }
   else {
@@ -801,7 +801,7 @@ bool elina_abstract0_sat_interval(elina_manager_t* man, elina_abstract0_t* a,
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_SAT_INTERVAL,man,a) &&
       elina_abstract0_check_dim(ELINA_FUNID_SAT_INTERVAL,man,_elina_abstract0_dimension(a),dim)){
-    bool (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_SAT_INTERVAL];
+    bool (*ptr)(elina_manager_t*,void*,elina_dim_t,elina_interval_t*) = man->funptr[ELINA_FUNID_SAT_INTERVAL];
     return ptr(man,a->value,dim,interval);
   }
   else {
@@ -814,7 +814,7 @@ bool elina_abstract0_is_dimension_unconstrained(elina_manager_t* man, elina_abst
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_IS_DIMENSION_UNCONSTRAINED,man,a) &&
       elina_abstract0_check_dim(ELINA_FUNID_IS_DIMENSION_UNCONSTRAINED,man,_elina_abstract0_dimension(a),dim)){
-    bool (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_DIMENSION_UNCONSTRAINED];
+    bool (*ptr)(elina_manager_t*,void*,elina_dim_t) = man->funptr[ELINA_FUNID_IS_DIMENSION_UNCONSTRAINED];
     return ptr(man,a->value,dim);
   }
   else {
@@ -831,7 +831,7 @@ elina_interval_t* elina_abstract0_bound_linexpr(elina_manager_t* man,
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_BOUND_LINEXPR,man,a) &&
       elina_abstract0_check_linexpr(ELINA_FUNID_BOUND_LINEXPR,man,_elina_abstract0_dimension(a),expr)){
-    elina_interval_t* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_BOUND_LINEXPR];
+    elina_interval_t* (*ptr)(elina_manager_t*,void*,elina_linexpr0_t*) = man->funptr[ELINA_FUNID_BOUND_LINEXPR];
     return ptr(man,a->value,expr);
   }
   else {
@@ -846,7 +846,7 @@ elina_interval_t* elina_abstract0_bound_texpr(elina_manager_t* man,
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_BOUND_TEXPR,man,a) &&
       elina_abstract0_check_texpr(ELINA_FUNID_BOUND_TEXPR,man,_elina_abstract0_dimension(a),expr)){
-    elina_interval_t* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_BOUND_TEXPR];
+    elina_interval_t* (*ptr)(elina_manager_t*,void*,elina_texpr0_t*) = man->funptr[ELINA_FUNID_BOUND_TEXPR];
     return ptr(man,a->value,expr);
   }
   else {
@@ -861,7 +861,7 @@ elina_interval_t* elina_abstract0_bound_dimension(elina_manager_t* man,
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_BOUND_DIMENSION,man,a) &&
       elina_abstract0_check_dim(ELINA_FUNID_BOUND_DIMENSION,man,_elina_abstract0_dimension(a),dim)){
-    elina_interval_t* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_BOUND_DIMENSION];
+    elina_interval_t* (*ptr)(elina_manager_t*,void*,elina_dim_t) = man->funptr[ELINA_FUNID_BOUND_DIMENSION];
     return ptr(man,a->value,dim);
   }
   else {
@@ -949,7 +949,7 @@ elina_abstract0_t* elina_abstract0_meetjoin_array(elina_funid_t funid, elina_man
       elina_abstract0_check_abstract_array(funid,man,tab,size)){
     size_t i;
     elina_abstract0_t* res;
-    void* (*ptr)(elina_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(elina_manager_t*,void**,size_t) = man->funptr[funid];
     void** ntab = malloc(size*sizeof(void*));
     for (i=0;i<size;i++) ntab[i] = tab[i]->value;
     res = elina_abstract0_cons(man,ptr(man,ntab,size));
@@ -980,7 +980,7 @@ elina_abstract0_t* elina_abstract0_meet_lincons_array(elina_manager_t* man,
   elina_dimension_t dimension = _elina_abstract0_dimension(a);
   if (elina_abstract0_checkman1(ELINA_FUNID_MEET_LINCONS_ARRAY,man,a) &&
       elina_abstract0_check_lincons_array(ELINA_FUNID_MEET_LINCONS_ARRAY,man,dimension,array) ){
-    void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
+    void* (*ptr)(elina_manager_t*,bool,void*,elina_lincons0_array_t*) = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
     void* value = ptr(man,destructive,a->value,array);
     return elina_abstract0_cons2(man,destructive,a,value);
   }
@@ -999,7 +999,7 @@ elina_abstract0_t* elina_abstract0_meet_tcons_array(elina_manager_t* man,
   elina_dimension_t dimension = _elina_abstract0_dimension(a);
   if (elina_abstract0_checkman1(ELINA_FUNID_MEET_TCONS_ARRAY,man,a) &&
       elina_abstract0_check_tcons_array(ELINA_FUNID_MEET_TCONS_ARRAY,man,dimension,array) ){
-    void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET_TCONS_ARRAY];
+    void* (*ptr)(elina_manager_t*,bool,void*,elina_tcons0_array_t*) = man->funptr[ELINA_FUNID_MEET_TCONS_ARRAY];
     void* value = ptr(man,destructive,a->value,array);
     return elina_abstract0_cons2(man,destructive,a,value);
   }
@@ -1042,7 +1042,7 @@ elina_abstract0_t* elina_abstract0_asssub_linexpr_array(elina_funid_t funid,
 	(dest!=NULL ? (elina_abstract0_checkman1(funid,man,dest) && elina_abstract0_check_abstract2(funid,man,a,dest)) : true) &&
 	elina_abstract0_check_dim_array(funid,man,dimension,tdim,size) &&
 	elina_abstract0_check_linexpr_array(funid,man,dimension,texpr,size) ){
-      void* (*ptr)(elina_manager_t*,...) = man->funptr[funid];
+      void* (*ptr)(elina_manager_t*,bool,void*,elina_dim_t*,elina_linexpr0_t**,size_t,void*) = man->funptr[funid];
       void* value = ptr(man,destructive,a->value,tdim,texpr,size,dest ? dest->value : NULL);
       return elina_abstract0_cons2(man,destructive,a,value);
     }
@@ -1102,7 +1102,7 @@ elina_abstract0_t* elina_abstract0_asssub_texpr_array(elina_funid_t funid,
 	(dest!=NULL ? (elina_abstract0_checkman1(funid,man,dest) && elina_abstract0_check_abstract2(funid,man,a,dest)) : true) &&
 	elina_abstract0_check_dim_array(funid,man,dimension,tdim,size) &&
 	elina_abstract0_check_texpr_array(funid,man,dimension,texpr,size) ){
-      void* (*ptr)(elina_manager_t*,...) = man->funptr[funid];
+      void* (*ptr)(elina_manager_t*,bool,void*,elina_dim_t*,elina_texpr0_t**,size_t,void*) = man->funptr[funid];
       void* value = ptr(man,destructive,a->value,tdim,texpr,size,dest ? dest->value : NULL);
       return elina_abstract0_cons2(man,destructive,a,value);
     }
@@ -1159,7 +1159,7 @@ elina_abstract0_t* elina_abstract0_forget_array(elina_manager_t* man,
     elina_dimension_t dimension = _elina_abstract0_dimension(a);
     if (elina_abstract0_checkman1(ELINA_FUNID_FORGET_ARRAY,man,a) &&
 	elina_abstract0_check_dim_array(ELINA_FUNID_FORGET_ARRAY,man,dimension,tdim,size)){
-      void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_FORGET_ARRAY];
+      void* (*ptr)(elina_manager_t*,bool,void*,elina_dim_t*,size_t,bool) = man->funptr[ELINA_FUNID_FORGET_ARRAY];
       void* value = ptr(man,destructive,a->value,tdim,size,project);
       return elina_abstract0_cons2(man,destructive,a,value);
     }
@@ -1194,7 +1194,7 @@ elina_abstract0_t* elina_abstract0_add_dimensions(elina_manager_t* man,
     elina_dimension_t dimension = _elina_abstract0_dimension(a);
     if (elina_abstract0_checkman1(ELINA_FUNID_ADD_DIMENSIONS,man,a) &&
 	elina_abstract0_check_elina_dimchange_add(ELINA_FUNID_ADD_DIMENSIONS,man,dimension,dimchange)){
-      void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_ADD_DIMENSIONS];
+      void* (*ptr)(elina_manager_t*,bool,void*,elina_dimchange_t*,bool) = man->funptr[ELINA_FUNID_ADD_DIMENSIONS];
       void* value = ptr(man,destructive,a->value,dimchange,project);
       return elina_abstract0_cons2(man,destructive,a,value);
     }
@@ -1223,7 +1223,7 @@ elina_abstract0_t* elina_abstract0_remove_dimensions(elina_manager_t* man,
     elina_dimension_t dimension = _elina_abstract0_dimension(a);
     if (elina_abstract0_checkman1(ELINA_FUNID_REMOVE_DIMENSIONS,man,a) &&
 	elina_abstract0_check_elina_dimchange_remove(ELINA_FUNID_REMOVE_DIMENSIONS,man,dimension,dimchange)){
-      void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_REMOVE_DIMENSIONS];
+      void* (*ptr)(elina_manager_t*,bool,void*,elina_dimchange_t*) = man->funptr[ELINA_FUNID_REMOVE_DIMENSIONS];
       void* value = ptr(man,destructive,a->value,dimchange);
       return elina_abstract0_cons2(man,destructive,a,value);
     }
@@ -1243,7 +1243,7 @@ elina_abstract0_t* elina_abstract0_permute_dimensions(elina_manager_t* man,
   elina_dimension_t dimension = _elina_abstract0_dimension(a);
   if (elina_abstract0_checkman1(ELINA_FUNID_PERMUTE_DIMENSIONS,man,a) &&
       elina_abstract0_check_dimperm(ELINA_FUNID_PERMUTE_DIMENSIONS,man,dimension,perm)){
-    void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_PERMUTE_DIMENSIONS];
+    void* (*ptr)(elina_manager_t*,bool,void*,elina_dimperm_t*) = man->funptr[ELINA_FUNID_PERMUTE_DIMENSIONS];
     void* value = ptr(man,destructive,a->value,perm);
     return elina_abstract0_cons2(man,destructive,a,value);
   }
@@ -1277,7 +1277,7 @@ elina_abstract0_t* elina_abstract0_expand(elina_manager_t* man,
     elina_dimension_t dimension = _elina_abstract0_dimension(a);
     if (elina_abstract0_checkman1(ELINA_FUNID_EXPAND,man,a) &&
 	elina_abstract0_check_dim(ELINA_FUNID_EXPAND,man,dimension,dim)){
-      void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_EXPAND];
+      void* (*ptr)(elina_manager_t*,bool,void*,elina_dim_t,size_t) = man->funptr[ELINA_FUNID_EXPAND];
       void* value = ptr(man,destructive,a->value,dim,n);
       return elina_abstract0_cons2(man,destructive,a,value);
     }
@@ -1335,7 +1335,7 @@ elina_abstract0_t* elina_abstract0_fold(elina_manager_t* man,
       }
     }
     else {
-      void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_FOLD];
+      void* (*ptr)(elina_manager_t*,bool,void*,elina_dim_t*,size_t) = man->funptr[ELINA_FUNID_FOLD];
       void* value = ptr(man,destructive,a->value,tdim,size);
       return elina_abstract0_cons2(man,destructive,a,value);
     }
@@ -1515,7 +1515,7 @@ elina_abstract0_t* elina_abstract0_widening_threshold(elina_manager_t* man,
     }
     if (i>0){
       array->size = i;
-      void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
+      void* (*ptr)(elina_manager_t*,bool,void*,elina_lincons0_array_t*) = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
       value = ptr(man,true,value,array);
       array->size = size;
     }

--- a/elina_auxiliary/elina_abstract0.c
+++ b/elina_auxiliary/elina_abstract0.c
@@ -10,7 +10,7 @@
  *  EXPRESS, IMPLIED OR STATUTORY, INCLUDING BUT NOT LIMITED TO ANY WARRANTY
  *  THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS OR BE ERROR-FREE AND ANY
  *  IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
- *  TITLE, OR NON-INFRINGEMENT.  IN NO EVENT SHALL ETH ZURICH BE LIABLE FOR ANY     
+ *  TITLE, OR NON-INFRINGEMENT.  IN NO EVENT SHALL ETH ZURICH BE LIABLE FOR ANY
  *  DAMAGES, INCLUDING BUT NOT LIMITED TO DIRECT, INDIRECT,
  *  SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM, OR IN
  *  ANY WAY CONNECTED WITH THIS SOFTWARE (WHETHER OR NOT BASED UPON WARRANTY,
@@ -451,7 +451,7 @@ bool elina_abstract0_check_elina_dimchange_add(elina_funid_t funid, elina_manage
   /* Check consistency between intdim and the dimensions in the array */
   for (i=0; i<dimchange->intdim; i++){
     if (dimchange->dim[i]>dimension.intdim){
-      
+
       res = false;
       break;
     }
@@ -463,7 +463,7 @@ bool elina_abstract0_check_elina_dimchange_add(elina_funid_t funid, elina_manage
     for (i=1; i<size; i++){
       if (dim>dimchange->dim[i]){
 	res = false;
-	
+
 	break;
       } else {
 	dim = dimchange->dim[i];
@@ -548,7 +548,7 @@ bool elina_abstract0_check_dimperm(elina_funid_t funid, elina_manager_t* man,
 elina_abstract0_t* elina_abstract0_copy(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_COPY,man,a)){
-    void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_COPY];
+    void* (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
     return elina_abstract0_cons(man,ptr(man,a->value));
   }
   else {
@@ -581,7 +581,7 @@ void elina_abstract0_free(elina_manager_t* man, elina_abstract0_t* a)
 size_t elina_abstract0_size(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_ASIZE,man,a)){
-    size_t (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_ASIZE];
+    size_t (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_ASIZE];
     return ptr(man,a->value);
   }
   else {
@@ -595,21 +595,21 @@ size_t elina_abstract0_size(elina_manager_t* man, elina_abstract0_t* a)
 void elina_abstract0_minimize(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_MINIMIZE,man,a)){
-    void (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MINIMIZE];
+    void (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_MINIMIZE];
     ptr(man,a->value);
   }
 }
 void elina_abstract0_canonicalize(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_CANONICALIZE,man,a)){
-    void (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_CANONICALIZE];
+    void (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_CANONICALIZE];
     ptr(man,a->value);
   }
 }
 int elina_abstract0_hash(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_CANONICALIZE,man,a)){
-    int (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_HASH];
+    int (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_HASH];
     return ptr(man,a->value);
   }
   else
@@ -618,7 +618,7 @@ int elina_abstract0_hash(elina_manager_t* man, elina_abstract0_t* a)
 void elina_abstract0_approximate(elina_manager_t* man, elina_abstract0_t* a, int n)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_APPROXIMATE,man,a)){
-    void (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_APPROXIMATE];
+    void (*ptr)(elina_manager_t*,void*,int) = man->funptr[ELINA_FUNID_APPROXIMATE];
     ptr(man,a->value,n);
   }
 }
@@ -655,7 +655,7 @@ void elina_abstract0_fprintdiff(FILE* stream, elina_manager_t* man,
 void elina_abstract0_fdump(FILE* stream, elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_FDUMP,man,a)){
-    void (*ptr)(FILE*,elina_manager_t*,...) = man->funptr[ELINA_FUNID_FDUMP];
+    void (*ptr)(FILE*,elina_manager_t*,void*) = man->funptr[ELINA_FUNID_FDUMP];
     ptr(stream,man,a->value);
   }
   else {
@@ -669,7 +669,7 @@ void elina_abstract0_fdump(FILE* stream, elina_manager_t* man, elina_abstract0_t
 elina_membuf_t elina_abstract0_serialize_raw(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_SERIALIZE_RAW,man,a)){
-    elina_membuf_t (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_SERIALIZE_RAW];
+    elina_membuf_t (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_SERIALIZE_RAW];
     return ptr(man,a->value);
   }
   else {
@@ -679,7 +679,7 @@ elina_membuf_t elina_abstract0_serialize_raw(elina_manager_t* man, elina_abstrac
 }
 elina_abstract0_t* elina_abstract0_deserialize_raw(elina_manager_t* man, void* p, size_t* size)
 {
-  void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_DESERIALIZE_RAW];
+  void* (*ptr)(elina_manager_t*,void*,size_t*) = man->funptr[ELINA_FUNID_DESERIALIZE_RAW];
   return elina_abstract0_cons(man,ptr(man,p,size));
 }
 
@@ -711,7 +711,7 @@ elina_abstract0_t* elina_abstract0_of_box(elina_manager_t* man,
 elina_dimension_t elina_abstract0_dimension(elina_manager_t* man, elina_abstract0_t* a)
 {
   elina_abstract0_checkman1(ELINA_FUNID_DIMENSION,man,a);
-  elina_dimension_t (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_DIMENSION];
+  elina_dimension_t (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_DIMENSION];
   return ptr(a->man,a->value);
 }
 
@@ -721,7 +721,7 @@ elina_dimension_t elina_abstract0_dimension(elina_manager_t* man, elina_abstract
 bool elina_abstract0_is_bottom(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_IS_BOTTOM,man,a)){
-    bool (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_BOTTOM];
+    bool (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
     return ptr(man,a->value);
   }
   else {
@@ -732,7 +732,7 @@ bool elina_abstract0_is_bottom(elina_manager_t* man, elina_abstract0_t* a)
 bool elina_abstract0_is_top(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_IS_TOP,man,a)){
-    bool (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_TOP];
+    bool (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_TOP];
     return ptr(man,a->value);
   }
   else {
@@ -748,7 +748,7 @@ bool elina_abstract0_is_leq(elina_manager_t* man, elina_abstract0_t* a1, elina_a
   else if (elina_abstract0_checkman2(ELINA_FUNID_IS_LEQ,man,a1,a2) &&
 	   elina_abstract0_check_abstract2(ELINA_FUNID_IS_EQ,man,a1,a2)){
     if (a1->value==a2->value) return true;
-    bool (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_LEQ];
+    bool (*ptr)(elina_manager_t*,void*,void*) = man->funptr[ELINA_FUNID_IS_LEQ];
     return ptr(man,a1->value,a2->value);
   }
   else {
@@ -764,7 +764,7 @@ bool elina_abstract0_is_eq(elina_manager_t* man, elina_abstract0_t* a1, elina_ab
   if (elina_abstract0_checkman2(ELINA_FUNID_IS_EQ,man,a1,a2) &&
       elina_abstract0_check_abstract2(ELINA_FUNID_IS_EQ,man,a1,a2)){
     if (a1->value==a2->value) return true;
-    bool (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_EQ];
+    bool (*ptr)(elina_manager_t*,void*,void*) = man->funptr[ELINA_FUNID_IS_EQ];
     return ptr(man,a1->value,a2->value);
   }
   else {
@@ -874,7 +874,7 @@ elina_interval_t* elina_abstract0_bound_dimension(elina_manager_t* man,
 elina_lincons0_array_t elina_abstract0_to_lincons_array(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_TO_LINCONS_ARRAY,man,a)){
-    elina_lincons0_array_t (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_TO_LINCONS_ARRAY];
+    elina_lincons0_array_t (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_TO_LINCONS_ARRAY];
     return ptr(man,a->value);
   }
   else {
@@ -885,7 +885,7 @@ elina_lincons0_array_t elina_abstract0_to_lincons_array(elina_manager_t* man, el
 elina_tcons0_array_t elina_abstract0_to_tcons_array(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_TO_TCONS_ARRAY,man,a)){
-    elina_tcons0_array_t (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_TO_TCONS_ARRAY];
+    elina_tcons0_array_t (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_TO_TCONS_ARRAY];
     return ptr(man,a->value);
   }
   else {
@@ -896,7 +896,7 @@ elina_tcons0_array_t elina_abstract0_to_tcons_array(elina_manager_t* man, elina_
 elina_interval_t** elina_abstract0_to_box(elina_manager_t* man, elina_abstract0_t* a)
 {
   if (elina_abstract0_checkman1(ELINA_FUNID_TO_BOX,man,a)){
-    elina_interval_t** (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_TO_BOX];
+    elina_interval_t** (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_TO_BOX];
     return ptr(man,a->value);
   }
   else {
@@ -924,7 +924,7 @@ elina_abstract0_t* elina_abstract0_meetjoin(elina_funid_t funid,
 {
   if (elina_abstract0_checkman2(funid,man,a1,a2) &&
       elina_abstract0_check_abstract2(funid,man,a1,a2)){
-    void* (*ptr)(elina_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(elina_manager_t*,bool,void*,void*) = man->funptr[funid];
     void* value = ptr(man,destructive,a1->value,a2->value);
     return elina_abstract0_cons2(man,destructive,a1,value);
   }
@@ -1264,7 +1264,7 @@ elina_abstract0_t* elina_abstract0_expand(elina_manager_t* man,
 				    elina_dim_t dim,
 				    size_t n)
 {
- 
+
   if (n==0){
     if (destructive){
 	return a;
@@ -1330,7 +1330,7 @@ elina_abstract0_t* elina_abstract0_fold(elina_manager_t* man,
 	return a;
       }
       else {
-	void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_COPY];
+	void* (*ptr)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
 	return elina_abstract0_cons(man,ptr(man,a->value));
       }
     }
@@ -1356,7 +1356,7 @@ elina_abstract0_t* elina_abstract0_widening(elina_manager_t* man,
 {
   if (elina_abstract0_checkman2(ELINA_FUNID_WIDENING,man,a1,a2) &&
       elina_abstract0_check_abstract2(ELINA_FUNID_WIDENING,man,a1,a2)){
-    void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_WIDENING];
+    void* (*ptr)(elina_manager_t*,void*,void*) = man->funptr[ELINA_FUNID_WIDENING];
     void* value = ptr(man,a1->value,a2->value);
     return elina_abstract0_cons(man,value);
   }
@@ -1375,7 +1375,7 @@ elina_abstract0_t* elina_abstract0_closure(elina_manager_t* man, bool destructiv
 {
   elina_dimension_t dimension = _elina_abstract0_dimension(a);
   if (elina_abstract0_checkman1(ELINA_FUNID_CLOSURE,man,a)){
-    void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_CLOSURE];
+    void* (*ptr)(elina_manager_t*,bool,void*) = man->funptr[ELINA_FUNID_CLOSURE];
     void* value = ptr(man,destructive,a->value);
     return elina_abstract0_cons2(man,destructive,a,value);
   }
@@ -1488,8 +1488,6 @@ elina_abstract0_t* elina_abstract0_widening_threshold(elina_manager_t* man,
 						elina_abstract0_t* a2,
 						elina_lincons0_array_t* array)
 {
-  void* (*ptr)(elina_manager_t*,...);
-  bool (*ptr2)(elina_manager_t*,...);
   void* value;
   size_t i,j,size;
   elina_lincons0_t tmp;
@@ -1498,10 +1496,10 @@ elina_abstract0_t* elina_abstract0_widening_threshold(elina_manager_t* man,
   if (elina_abstract0_checkman2(ELINA_FUNID_WIDENING,man,a1,a2) &&
       elina_abstract0_check_abstract2(ELINA_FUNID_WIDENING,man,a1,a2) &&
       elina_abstract0_check_lincons_array(ELINA_FUNID_WIDENING,man,dimension,array) ){
-    ptr = man->funptr[ELINA_FUNID_WIDENING];
+    void* (*ptr)(elina_manager_t*,void*,void*) = man->funptr[ELINA_FUNID_WIDENING];
     value = ptr(man,a1->value,a2->value);
 
-    ptr2 = man->funptr[ELINA_FUNID_SAT_LINCONS];
+    bool (*ptr2)(elina_manager_t*,void*,void*) = man->funptr[ELINA_FUNID_SAT_LINCONS];
     size = array->size;
     i = j = 0;
     while (i<size-j){
@@ -1517,7 +1515,7 @@ elina_abstract0_t* elina_abstract0_widening_threshold(elina_manager_t* man,
     }
     if (i>0){
       array->size = i;
-      ptr = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
+      void* (*ptr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
       value = ptr(man,true,value,array);
       array->size = size;
     }

--- a/elina_auxiliary/elina_abstract0.h
+++ b/elina_auxiliary/elina_abstract0.h
@@ -10,7 +10,7 @@
  *  EXPRESS, IMPLIED OR STATUTORY, INCLUDING BUT NOT LIMITED TO ANY WARRANTY
  *  THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS OR BE ERROR-FREE AND ANY
  *  IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
- *  TITLE, OR NON-INFRINGEMENT.  IN NO EVENT SHALL ETH ZURICH BE LIABLE FOR ANY     
+ *  TITLE, OR NON-INFRINGEMENT.  IN NO EVENT SHALL ETH ZURICH BE LIABLE FOR ANY
  *  DAMAGES, INCLUDING BUT NOT LIMITED TO DIRECT, INDIRECT,
  *  SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM, OR IN
  *  ANY WAY CONNECTED WITH THIS SOFTWARE (WHETHER OR NOT BASED UPON WARRANTY,
@@ -526,7 +526,7 @@ bool elina_abstract0_checkman_array(elina_funid_t funid,
 static inline
 elina_dimension_t _elina_abstract0_dimension(elina_abstract0_t* a)
 {
-  elina_dimension_t (*ptr)(elina_manager_t*,...) = (elina_dimension_t (*) (elina_manager_t*,...))(a->man->funptr[ELINA_FUNID_DIMENSION]);
+  elina_dimension_t (*ptr)(elina_manager_t*,void*) = (elina_dimension_t (*) (elina_manager_t*,void*))(a->man->funptr[ELINA_FUNID_DIMENSION]);
   return ptr(a->man,a->value);
 }
 

--- a/elina_linearize/elina_generic.c
+++ b/elina_linearize/elina_generic.c
@@ -10,7 +10,7 @@
  *  EXPRESS, IMPLIED OR STATUTORY, INCLUDING BUT NOT LIMITED TO ANY WARRANTY
  *  THAT THE SOFTWARE WILL CONFORM TO SPECIFICATIONS OR BE ERROR-FREE AND ANY
  *  IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
- *  TITLE, OR NON-INFRINGEMENT.  IN NO EVENT SHALL ETH ZURICH BE LIABLE FOR ANY     
+ *  TITLE, OR NON-INFRINGEMENT.  IN NO EVENT SHALL ETH ZURICH BE LIABLE FOR ANY
  *  DAMAGES, INCLUDING BUT NOT LIMITED TO DIRECT, INDIRECT,
  *  SPECIAL OR CONSEQUENTIAL DAMAGES, ARISING OUT OF, RESULTING FROM, OR IN
  *  ANY WAY CONNECTED WITH THIS SOFTWARE (WHETHER OR NOT BASED UPON WARRANTY,
@@ -45,7 +45,7 @@ bool elina_generic_sat_tcons(elina_manager_t* man, void* abs, elina_tcons0_t* co
 			     elina_scalar_discr_t discr,
 			     bool quasilinearize)
 {
-  bool (*is_bottom)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_BOTTOM];
+  bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
   bool (*sat_lincons)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_SAT_LINCONS];
   bool exact;
   elina_lincons0_t lincons0;
@@ -75,7 +75,7 @@ bool elina_generic_sat_tcons(elina_manager_t* man, void* abs, elina_tcons0_t* co
 elina_interval_t* elina_generic_bound_texpr(elina_manager_t* man, void* abs, elina_texpr0_t* expr,
 				      elina_scalar_discr_t discr, bool quasilinearize)
 {
-  bool (*is_bottom)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_BOTTOM];
+  bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
   elina_interval_t* (*bound_linexpr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_BOUND_LINEXPR];
   bool exact;
   elina_linexpr0_t* linexpr0;
@@ -102,7 +102,7 @@ elina_interval_t* elina_generic_bound_texpr(elina_manager_t* man, void* abs, eli
 elina_tcons0_array_t elina_generic_to_tcons_array(elina_manager_t* man,
 					    void* abs)
 {
-  elina_lincons0_array_t (*to_lincons_array)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_TO_LINCONS_ARRAY];
+  elina_lincons0_array_t (*to_lincons_array)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_TO_LINCONS_ARRAY];
   elina_lincons0_array_t array = to_lincons_array(man,abs);
   elina_tcons0_array_t res = elina_tcons0_array_make(array.size);
   size_t i;
@@ -130,8 +130,8 @@ void* elina_generic_meetjoin_array(bool meet,
 				elina_manager_t* man,
 				void** tab, size_t size)
 {
-  void* (*copy)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_COPY];
-  void* (*meetjoin)(elina_manager_t*,...) = man->funptr[meet ? ELINA_FUNID_MEET : ELINA_FUNID_JOIN];
+  void* (*copy)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
+  void* (*meetjoin)(elina_manager_t*,bool,void*,void*) = man->funptr[meet ? ELINA_FUNID_MEET : ELINA_FUNID_JOIN];
   size_t i;
   void* res;
   bool exact,best;
@@ -171,8 +171,8 @@ elina_generic_meet_quasilinearize_lincons_array(elina_manager_t* man,
   bool exact;
   elina_lincons0_array_t array2;
   void* res;
-  void* (*copy)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_COPY];
-  bool (*is_bottom)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_BOTTOM];
+  void* (*copy)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
+  bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
 
   man->result.flag_exact = man->result.flag_best = true;
 
@@ -207,8 +207,8 @@ elina_generic_meet_intlinearize_tcons_array(elina_manager_t* man,
   bool exact;
   elina_lincons0_array_t array2;
   void* res;
-  void* (*copy)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_COPY];
-  bool (*is_bottom)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_BOTTOM];
+  void* (*copy)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
+  bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
   elina_abstract0_t a0;
 
   man->result.flag_exact = man->result.flag_best = true;
@@ -224,7 +224,7 @@ elina_generic_meet_intlinearize_tcons_array(elina_manager_t* man,
     if (!exact){
       man->result.flag_exact = man->result.flag_best = false;
     }
-	
+
     elina_lincons0_array_clear(&array2);
   }
   return res;
@@ -263,15 +263,15 @@ void* elina_generic_asssub_linexpr_array(bool assign,
 				      bool destructive, void* abs, elina_dim_t* tdim, elina_linexpr0_t** texpr, size_t size,
 				      void* dest)
 {
-  bool (*is_bottom)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_BOTTOM];
-  void* (*copy)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_COPY];
+  bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
+  void* (*copy)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
   void* (*add_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_ADD_DIMENSIONS];
   void* (*permute_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_PERMUTE_DIMENSIONS];
   void* (*remove_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_REMOVE_DIMENSIONS];
   void* (*meet_lincons_array)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
-  void* (*meet)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET];
-  void (*elina_free)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_FREE];
-  elina_dimension_t (*dimension)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_DIMENSION];
+  void* (*meet)(elina_manager_t*,bool,void*,void*) = man->funptr[ELINA_FUNID_MEET];
+  void (*elina_free)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_FREE];
+  elina_dimension_t (*dimension)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_DIMENSION];
   size_t i;
   elina_dimension_t d, dsup;
   elina_dimchange_t dimchange;
@@ -398,15 +398,15 @@ void* elina_generic_asssub_texpr_array(bool assign,
 				    bool destructive, void* abs, elina_dim_t* tdim, elina_texpr0_t** texpr, size_t size,
 				    void* dest)
 {
-  bool (*is_bottom)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_IS_BOTTOM];
-  void* (*copy)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_COPY];
+  bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
+  void* (*copy)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
   void* (*add_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_ADD_DIMENSIONS];
   void* (*permute_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_PERMUTE_DIMENSIONS];
   void* (*remove_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_REMOVE_DIMENSIONS];
   void* (*meet_tcons_array)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET_TCONS_ARRAY];
-  void* (*meet)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET];
-  void (*elina_free)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_FREE];
-  elina_dimension_t (*dimension)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_DIMENSION];
+  void* (*meet)(elina_manager_t*,bool,void*,void*) = man->funptr[ELINA_FUNID_MEET];
+  void (*elina_free)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_FREE];
+  elina_dimension_t (*dimension)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_DIMENSION];
   size_t i;
   elina_dimension_t d, dsup;
   elina_dimchange_t dimchange;

--- a/elina_linearize/elina_generic.c
+++ b/elina_linearize/elina_generic.c
@@ -46,7 +46,7 @@ bool elina_generic_sat_tcons(elina_manager_t* man, void* abs, elina_tcons0_t* co
 			     bool quasilinearize)
 {
   bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
-  bool (*sat_lincons)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_SAT_LINCONS];
+  bool (*sat_lincons)(elina_manager_t*,void*,elina_lincons0_t*) = man->funptr[ELINA_FUNID_SAT_LINCONS];
   bool exact;
   elina_lincons0_t lincons0;
   bool res;
@@ -76,7 +76,7 @@ elina_interval_t* elina_generic_bound_texpr(elina_manager_t* man, void* abs, eli
 				      elina_scalar_discr_t discr, bool quasilinearize)
 {
   bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
-  elina_interval_t* (*bound_linexpr)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_BOUND_LINEXPR];
+  elina_interval_t* (*bound_linexpr)(elina_manager_t*,void*,elina_linexpr0_t*) = man->funptr[ELINA_FUNID_BOUND_LINEXPR];
   bool exact;
   elina_linexpr0_t* linexpr0;
   elina_interval_t* res;
@@ -265,10 +265,10 @@ void* elina_generic_asssub_linexpr_array(bool assign,
 {
   bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
   void* (*copy)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
-  void* (*add_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_ADD_DIMENSIONS];
-  void* (*permute_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_PERMUTE_DIMENSIONS];
-  void* (*remove_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_REMOVE_DIMENSIONS];
-  void* (*meet_lincons_array)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
+  void* (*add_dimensions)(elina_manager_t*,bool,void*,elina_dimchange_t*,bool) = man->funptr[ELINA_FUNID_ADD_DIMENSIONS];
+  void* (*permute_dimensions)(elina_manager_t*,bool,void*,elina_dimperm_t*) = man->funptr[ELINA_FUNID_PERMUTE_DIMENSIONS];
+  void* (*remove_dimensions)(elina_manager_t*,bool,void*,elina_dimchange_t*) = man->funptr[ELINA_FUNID_REMOVE_DIMENSIONS];
+  void* (*meet_lincons_array)(elina_manager_t*,bool,void*,elina_lincons0_array_t*) = man->funptr[ELINA_FUNID_MEET_LINCONS_ARRAY];
   void* (*meet)(elina_manager_t*,bool,void*,void*) = man->funptr[ELINA_FUNID_MEET];
   void (*elina_free)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_FREE];
   elina_dimension_t (*dimension)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_DIMENSION];
@@ -400,10 +400,10 @@ void* elina_generic_asssub_texpr_array(bool assign,
 {
   bool (*is_bottom)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_IS_BOTTOM];
   void* (*copy)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_COPY];
-  void* (*add_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_ADD_DIMENSIONS];
-  void* (*permute_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_PERMUTE_DIMENSIONS];
-  void* (*remove_dimensions)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_REMOVE_DIMENSIONS];
-  void* (*meet_tcons_array)(elina_manager_t*,...) = man->funptr[ELINA_FUNID_MEET_TCONS_ARRAY];
+  void* (*add_dimensions)(elina_manager_t*,bool,void*,elina_dimchange_t*,bool) = man->funptr[ELINA_FUNID_ADD_DIMENSIONS];
+  void* (*permute_dimensions)(elina_manager_t*,bool,void*,elina_dimperm_t*) = man->funptr[ELINA_FUNID_PERMUTE_DIMENSIONS];
+  void* (*remove_dimensions)(elina_manager_t*,bool,void*,elina_dimchange_t*) = man->funptr[ELINA_FUNID_REMOVE_DIMENSIONS];
+  void* (*meet_tcons_array)(elina_manager_t*,bool,void*,elina_tcons0_array_t*) = man->funptr[ELINA_FUNID_MEET_TCONS_ARRAY];
   void* (*meet)(elina_manager_t*,bool,void*,void*) = man->funptr[ELINA_FUNID_MEET];
   void (*elina_free)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_FREE];
   elina_dimension_t (*dimension)(elina_manager_t*,void*) = man->funptr[ELINA_FUNID_DIMENSION];

--- a/elina_oct/opt_oct_hmat.h
+++ b/elina_oct/opt_oct_hmat.h
@@ -79,7 +79,10 @@ extern "C" {
 	extern double sat_lincons_time;
 	extern double assign_linexpr_time;
 	extern double oct_is_unconstrained_time;
-        extern double narrowing_time;
+	extern double narrowing_time;
+#else
+    #define start_timing()
+    #define record_timing(X)
 #endif
 
 #define min fmin

--- a/elina_poly/opt_pk_internal.h
+++ b/elina_poly/opt_pk_internal.h
@@ -72,6 +72,11 @@ extern "C" {
 	extern double opt_conversion_time;
 	extern long int join_count;
 	extern double poly_is_unconstrained_time;
+#else
+    #define start_timing()
+    #define record_timing(X)
+
+    static long int join_count;
 #endif
 /* ********************************************************************** */
 /* I. Types */

--- a/elina_zonotope/zonotope_internal.h
+++ b/elina_zonotope/zonotope_internal.h
@@ -38,6 +38,7 @@
 extern "C" {
 #endif
 
+#if defined(TIMING)
 #define start_timing()				\
 tsc_counter start, end;				\
 double cycles;					\
@@ -77,6 +78,10 @@ counter += cycles
     //extern double opt_conversion_time;
     //extern long int join_count;
     //extern double poly_is_unconstrained_time;
+#else
+    #define start_timing()
+    #define record_timing(X)
+#endif
     
 typedef unsigned  int uint_t;
 

--- a/zonoml/zonoml_internal.h
+++ b/zonoml/zonoml_internal.h
@@ -39,6 +39,7 @@
 extern "C" {
 #endif
 
+#if defined(TIMING)
 #define start_timing()				\
 tsc_counter start, end;				\
 double cycles;					\
@@ -59,6 +60,10 @@ counter += cycles
     extern double zonoml_conv_matmult_time;
     extern double zonoml_ffn_matmult_time;
 
+#else
+    #define start_timing()
+    #define record_timing(X)
+#endif
 
 
  


### PR DESCRIPTION
This PR addresses two portability issues:
 * The setting or un-setting of `-DTIMING` was not respected everywhere. Since the timing primitives use x86 assembly, this was a blocker.
 * Variadic function calls follow a different convention from fixed-parameter ones on ARM processors. So function pointers of type `void *(*)(elina_manager_t*,...)` were replaced with their specific counterparts.

Fixes #88.